### PR TITLE
Enable path overriding in the `handleDownload` method.

### DIFF
--- a/lib/YDStreamExtractor.py
+++ b/lib/YDStreamExtractor.py
@@ -378,7 +378,7 @@ def handleDownload(info, duration=None, bg=False, path=None):
     Returns a DownloadResult object for foreground transfers.
     """
     info = _convertInfo(info)
-    path = StreamUtils.getDownloadPath()
+    path = path or StreamUtils.getDownloadPath()
     if bg:
         servicecontrol.ServiceControl().download(info, path, duration)
     else:


### PR DESCRIPTION
This fixes overriding the download path when calling the `handleDownload` method (resolves #7).

This is useful for addons that generate paths dynamically (e.g. using subfolders).