### PR TITLE
Fixed percentage calculation for when total download size is estimated.

### DIFF
--- a/lib/YoutubeDLWrapper.py
+++ b/lib/YoutubeDLWrapper.py
@@ -204,7 +204,7 @@ class YoutubeDLWrapper(youtube_dl.YoutubeDL):
         # 'eta': eta,
         # 'speed': speed
         sofar = info.get('downloaded_bytes')
-        total = info.get('total_bytes')
+        total = info.get('total_bytes') or info.get('total_bytes_estimate')
         if info.get('filename'):
             self._lastDownloadedFilePath = info.get('filename')
         pct = ''


### PR DESCRIPTION
This patch uses the estimated download size as fallback for the given download size in order to estimate download progress in `YoutubeDLWrapper`.

In my use case, the info object passed by youtube-dl to `YoutubeDLWrapper` does not contain the `total_bytes` attribute that's currently being used to calculate progress; resulting in a constant progress of zero. However, the attribute `total_bytes_estimate` is present and turns out to be the actual download size.