### PR TITLE
Hight or Lenth seems sometime be None, so the Default Setting is used

### DIFF
--- a/lib/YDStreamExtractor.py
+++ b/lib/YDStreamExtractor.py
@@ -86,11 +86,11 @@ def _selectVideoQuality(r, quality=None):
                 if disable_dash and 'dash' in fdata.get('format_note', '').lower():
                     continue
                 h = fdata['height']
-                if h==None:
-                   h=1	
+                if h == None:
+                   h = 1	
                 p = fdata.get('preference', 1)
-                if p==None:
-                   p=1
+                if p == None:
+                   p = 1
                 if h >= minHeight and h <= maxHeight:
                     if (h >= prefMax and p > prefPref) or (h > prefMax and p >= prefPref):
                         prefMax = h

--- a/lib/YDStreamExtractor.py
+++ b/lib/YDStreamExtractor.py
@@ -86,7 +86,11 @@ def _selectVideoQuality(r, quality=None):
                 if disable_dash and 'dash' in fdata.get('format_note', '').lower():
                     continue
                 h = fdata['height']
+                if h==None:
+                   h=1	
                 p = fdata.get('preference', 1)
+                if p==None:
+                   p=1
                 if h >= minHeight and h <= maxHeight:
                     if (h >= prefMax and p > prefPref) or (h > prefMax and p >= prefPref):
                         prefMax = h


### PR DESCRIPTION
The Hight and Width seems sometime be None
Setting 0 would also cause errors if both atributes are empty
Setting it to 1 causes that one Stream is used, but when he finds a Video with an Sice it would be used instead