### PR TITLE
Fix __repr__ for datetime redefinition

### DIFF
--- a/lib/YoutubeDLWrapper.py
+++ b/lib/YoutubeDLWrapper.py
@@ -55,12 +55,18 @@ try:
     datetime.datetime.strptime('0', '%H')
 except TypeError:
     # Fix for datetime issues with XBMC/Kodi
-    class new_datetime(datetime.datetime):
-        @classmethod
-        def strptime(cls, dstring, dformat):
-            return datetime.datetime(*(time.strptime(dstring, dformat)[0:6]))
+    def redefine_datetime(orig):
+        class datetime(orig):
+            @classmethod
+            def strptime(cls, dstring, dformat):
+                return datetime.datetime(*(time.strptime(dstring, dformat)[0:6]))
 
-    datetime.datetime = new_datetime
+            def __repr__(self):
+                return 'datetime.' + orig.__repr__(self)
+
+        return datetime
+
+    datetime.datetime = redefine_datetime(datetime.datetime)
 
 # _utils_unified_strdate = youtube_dl.utils.unified_strdate
 # _utils_date_from_str = youtube_dl.utils.date_from_str


### PR DESCRIPTION
repr() of a datetime.datetime object got 'new_datetime' as the class name,
this led to errors with the SimpleCache module that tried to restore the
representation but could not find the new_datetime class.

This fix changes the __repr__ function of the new class to show
'datetime.datetime' as the classes name.

https://pastebin.com/3Q6s1MK7 shows such errors that occurred.