### PR TITLE
[fix] Use new abortRequested API

### DIFF
--- a/lib/YoutubeDLWrapper.py
+++ b/lib/YoutubeDLWrapper.py
@@ -201,6 +201,7 @@ class YoutubeDLWrapper(youtube_dl.YoutubeDL):
     def __init__(self, *args, **kwargs):
         self._lastDownloadedFilePath = ''
         self._overrideParams = {}
+        self._monitor = xbmc.Monitor()
 
         youtube_dl.YoutubeDL.__init__(self, *args, **kwargs)
 
@@ -213,14 +214,14 @@ class YoutubeDLWrapper(youtube_dl.YoutubeDL):
                 util.ERROR('Error in callback. Removing.')
                 _CALLBACK = None
         else:
-            if xbmc.abortRequested:
+            if self._monitor.abortRequested():
                 raise Exception('abortRequested')
             # print msg.encode('ascii','replace')
         return True
 
     def progressCallback(self, info):
         global _DOWNLOAD_CANCEL
-        if xbmc.abortRequested or _DOWNLOAD_CANCEL:
+        if self._monitor.abortRequested() or _DOWNLOAD_CANCEL:
             _DOWNLOAD_CANCEL = False
             raise DownloadCanceledException('abortRequested')
         if _DOWNLOAD_DURATION:

--- a/service.py
+++ b/service.py
@@ -50,13 +50,14 @@ class Service():
     def _start(self):
         util.LOG('DOWNLOAD SERVICE: START')
         info = self.getNextQueuedDownload()
+        monitor = xbmc.Monitor()
 
-        while info and not xbmc.abortRequested:
+        while info and not monitor.abortRequested():
             t = threading.Thread(target=YDStreamExtractor._handleDownload, args=(
                 info['data'],), kwargs={'path': info['path'], 'duration': info['duration'], 'bg': True})
             t.start()
 
-            while t.isAlive() and not xbmc.abortRequested:
+            while t.isAlive() and not monitor.abortRequested():
                 xbmc.sleep(100)
 
             info = self.getNextQueuedDownload()


### PR DESCRIPTION
`xbmc.abortRequested` is deprecated and we should use `xbmc.Monitor().abortRequested()` now (see: https://kodi.wiki/view/Service_add-ons).

In addition, there is a bug with `xbmc.abortRequested` if Youtube-DL is called from a Python add-on that use the `reuselanguageinvoker` feature ; in this case, `xbmc.abortRequested` always return `True` even if Kodi is not exiting.

**Conclusion:** Youtube-DL is completely broken on Video add-on that use `reuselanguageinvoker` because we always get a `Exception('abortRequested')`