### PR TITLE
Resolve datetime attribute issues

### DIFF
--- a/lib/YoutubeDLWrapper.py
+++ b/lib/YoutubeDLWrapper.py
@@ -59,7 +59,10 @@ except TypeError:
         class datetime(orig):
             @classmethod
             def strptime(cls, dstring, dformat):
-                return datetime.datetime(*(time.strptime(dstring, dformat)[0:6]))
+                try:
+                    return datetime.datetime(*(time.strptime(dstring, dformat)[0:6]))
+                except AttributeError:
+                    return datetime(*(time.strptime(dstring, dformat)[0:6]))
 
             def __repr__(self):
                 return 'datetime.' + orig.__repr__(self)


### PR DESCRIPTION
Using your module as a module within other addons results sometimes in a datetime attribute error.

`2020-08-12 20:50:49.142 T:3709     INFO <general>: script.module.youtube.dl: _getYoutubeDLVideo() failed::getVideoInfo (383) - type object 'datetime' has no attribute 'datetime'
2020-08-12 20:50:49.142 T:3709    ERROR <general>: [plugin.video.kn_ves 0.0.6+matrix] Could not extract video stream`

This fix resolves this behaviour.